### PR TITLE
patch: CRM-521 don't commit .npmrc that have tokens

### DIFF
--- a/.github/workflows/merged-lib-pr.yml
+++ b/.github/workflows/merged-lib-pr.yml
@@ -106,7 +106,8 @@ jobs:
           npm install --package-lock-only --no-audit
           git config --local user.email $GITHUB_EMAIL
           git config --local user.name $GITHUB_USER
-          git commit -m "Sync package-lock.json to ${BUMPED_VERSION}" -a
+          git add package-lock.json
+          git commit -m "Sync package-lock.json to ${BUMPED_VERSION}"
           git push ${REMOTE_REPO} HEAD:main
         env:
           BUMPED_VERSION: ${{ steps.bump_version.outputs.next_version }}

--- a/.github/workflows/merged-pr.yml
+++ b/.github/workflows/merged-pr.yml
@@ -138,7 +138,8 @@ jobs:
           npm install --package-lock-only --no-audit
           git config --local user.email $GITHUB_EMAIL
           git config --local user.name $GITHUB_USER
-          git commit -m "Sync package-lock.json to ${BUMPED_VERSION}" -a
+          git add package-lock.json
+          git commit -m "Sync package-lock.json to ${BUMPED_VERSION}"
           git push ${REMOTE_REPO} HEAD:main
         env: 
           BUMPED_VERSION: ${{ steps.bump_version.outputs.next_version }}


### PR DESCRIPTION
We need to ignore committing `.npmrc` files to avoid such [updates](https://github.com/ultimateai/zendesk-support-automation/commit/b7bb97c6c5c2237a77e4a279cd3998bbc5a6a8fc)