### PR TITLE
bump changed files action

### DIFF
--- a/.github/workflows/ts_open-pr.yml
+++ b/.github/workflows/ts_open-pr.yml
@@ -36,7 +36,6 @@ env:
   NPM_INSTALL_COMMAND: ${{ inputs.npm_install_command }}
   NODE_VERSION: ${{ inputs.node_version }}
 
-
 jobs:
   test_build:
     runs-on: preemptible-runners
@@ -49,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -91,11 +90,11 @@ jobs:
             npm run artifactregistry-login -- --credential-config .npmrc
           fi
           $NPM_INSTALL_COMMAND
-      
+
       - name: Lint
         if: ${{ env.LINT_COMMAND }}
         run: $LINT_COMMAND
-          
+
       - name: Test
         if: ${{ env.TEST_COMMAND }}
         run: $TEST_COMMAND
@@ -106,7 +105,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v32.1.2
+        uses: tj-actions/changed-files@v36.0.17
 
       - name: Docker build if Dockerfile has changed
         if: contains(steps.changed-files.outputs.modified_files, 'Dockerfile')


### PR DESCRIPTION
I'm having some issues with the `changed-files` action and maybe bumping the version might fix it as we are using an older version.
Let me know if the version was locked on purpose!