### PR TITLE
feat: PLAT-000 Add docker-login support for zendesk-base-images

### DIFF
--- a/.github/workflows/cron_deploy-from-branch.yml
+++ b/.github/workflows/cron_deploy-from-branch.yml
@@ -80,6 +80,7 @@ env:
   GAR_ENABLED: ${{ vars.GAR_ENABLED || 'true' }}
   GCR_DEFAULT_REPO: ${{ vars.GCR_DEFAULT_REPO }}
   GAR_DEFAULT_REPO: ${{ vars.GAR_DEFAULT_REPO }}
+  ZENDESK_BASE_IMAGES_REPO: ${{ vars.ZENDESK_BASE_IMAGES_REPO || 'europe-west1-docker.pkg.dev/common-main-cfc4/zendesk-base-images' }}
   REGION: ${{ inputs.region }}
   AVAILABLE_REGIONS_FOR_DEPLOYMENT: ${{ vars.AVAILABLE_REGIONS_FOR_DEPLOYMENT }}
 
@@ -150,6 +151,8 @@ jobs:
             IMAGE_NAME=$GCR_IMAGE_NAME
           fi
 
+          ZENDESK_BASE_IMAGES_DOMAIN=$(echo $ZENDESK_BASE_IMAGES_REPO | cut -d '/' -f 1)
+
           echo "gcr_domain=$GCR_DOMAIN" >> $GITHUB_OUTPUT
           echo "gar_domain=$GAR_DOMAIN" >> $GITHUB_OUTPUT
           echo "gcr_image_repo=$GCR_IMAGE_REPO" >> $GITHUB_OUTPUT
@@ -157,6 +160,7 @@ jobs:
           echo "gcr_image_name=$GCR_IMAGE_NAME" >> $GITHUB_OUTPUT
           echo "gar_image_name=$GAR_IMAGE_NAME" >> $GITHUB_OUTPUT
           echo "image_name=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          echo "zendesk_base_images_domain=$ZENDESK_BASE_IMAGES_DOMAIN" >> $GITHUB_OUTPUT
 
       - name: Get .env file and scheduler for europe region
         if: ${{ env.REGION == 'europe' }}
@@ -214,6 +218,13 @@ jobs:
       - name: build
         if: ${{ env.BUILD_COMMAND }}
         run: $BUILD_COMMAND
+
+      - name: "Authenticating docker for zendesk-base-images dependencies"
+        uses: docker/login-action@v3
+        with:
+          registry: "${{ steps.image_name.outputs.ZENDESK_BASE_IMAGES_DOMAIN }}"
+          username: "oauth2accesstoken"
+          password: "${{ steps.auth.outputs.access_token }}"
 
       - name: "Authenticating docker to push to gcr"
         if: ${{ env.GCR_ENABLED == 'true' }}

--- a/.github/workflows/cron_merged-pr.yml
+++ b/.github/workflows/cron_merged-pr.yml
@@ -97,6 +97,7 @@ env:
   GAR_ENABLED: ${{ vars.GAR_ENABLED || 'true' }}
   GCR_DEFAULT_REPO: ${{ vars.GCR_DEFAULT_REPO }}
   GAR_DEFAULT_REPO: ${{ vars.GAR_DEFAULT_REPO }}
+  ZENDESK_BASE_IMAGES_REPO: ${{ vars.ZENDESK_BASE_IMAGES_REPO || 'europe-west1-docker.pkg.dev/common-main-cfc4/zendesk-base-images' }}
   REGION: ${{ inputs.region }}
   AVAILABLE_REGIONS_FOR_DEPLOYMENT: ${{ vars.AVAILABLE_REGIONS_FOR_DEPLOYMENT }}
 
@@ -225,6 +226,8 @@ jobs:
             IMAGE_NAME=$GCR_IMAGE_NAME
           fi
 
+          ZENDESK_BASE_IMAGES_DOMAIN=$(echo $ZENDESK_BASE_IMAGES_REPO | cut -d '/' -f 1)
+
           echo "gcr_domain=$GCR_DOMAIN" >> $GITHUB_OUTPUT
           echo "gar_domain=$GAR_DOMAIN" >> $GITHUB_OUTPUT
           echo "gcr_image_repo=$GCR_IMAGE_REPO" >> $GITHUB_OUTPUT
@@ -232,6 +235,8 @@ jobs:
           echo "gcr_image_name=$GCR_IMAGE_NAME" >> $GITHUB_OUTPUT
           echo "gar_image_name=$GAR_IMAGE_NAME" >> $GITHUB_OUTPUT
           echo "image_name=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          echo "zendesk_base_images_domain=$ZENDESK_BASE_IMAGES_DOMAIN" >> $GITHUB_OUTPUT
+
 
       - name: Get environment.env file and scheduler for updating k8s-manifest repo in europe region scenario
         if: ${{ env.REGION == 'europe' }}
@@ -277,6 +282,13 @@ jobs:
           token_format: "access_token"
           workload_identity_provider: "${{ secrets.WIF_PROVIDER_NAME }}"
           service_account: ${{ secrets.GSA_GCR_EMAIL }}
+
+      - name: "Authenticating docker for zendesk-base-images dependencies"
+        uses: docker/login-action@v3
+        with:
+          registry: "${{ steps.image_name.outputs.ZENDESK_BASE_IMAGES_DOMAIN }}"
+          username: "oauth2accesstoken"
+          password: "${{ steps.auth.outputs.access_token }}"
 
       - name: "Authenticating docker to push to gcr"
         if: ${{ env.GCR_ENABLED == 'true' }}

--- a/.github/workflows/deploy-from-branch.yml
+++ b/.github/workflows/deploy-from-branch.yml
@@ -95,6 +95,7 @@ env:
   GAR_ENABLED: ${{ vars.GAR_ENABLED || 'true' }}
   GCR_DEFAULT_REPO: ${{ vars.GCR_DEFAULT_REPO }}
   GAR_DEFAULT_REPO: ${{ vars.GAR_DEFAULT_REPO }}
+  ZENDESK_BASE_IMAGES_REPO: ${{ vars.ZENDESK_BASE_IMAGES_REPO || 'europe-west1-docker.pkg.dev/common-main-cfc4/zendesk-base-images' }}
   REGION: ${{ inputs.region }}
   AVAILABLE_REGIONS_FOR_DEPLOYMENT: ${{ vars.AVAILABLE_REGIONS_FOR_DEPLOYMENT }}
   CEREBRO_TEAM: ${{ inputs.cerebro_team }}
@@ -164,6 +165,8 @@ jobs:
             IMAGE_NAME=$GCR_IMAGE_NAME
           fi
 
+          ZENDESK_BASE_IMAGES_DOMAIN=$(echo $ZENDESK_BASE_IMAGES_REPO | cut -d '/' -f 1)
+
           echo "gcr_domain=$GCR_DOMAIN" >> $GITHUB_OUTPUT
           echo "gar_domain=$GAR_DOMAIN" >> $GITHUB_OUTPUT
           echo "gcr_image_repo=$GCR_IMAGE_REPO" >> $GITHUB_OUTPUT
@@ -171,6 +174,7 @@ jobs:
           echo "gcr_image_name=$GCR_IMAGE_NAME" >> $GITHUB_OUTPUT
           echo "gar_image_name=$GAR_IMAGE_NAME" >> $GITHUB_OUTPUT
           echo "image_name=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          echo "zendesk_base_images_domain=$ZENDESK_BASE_IMAGES_DOMAIN" >> $GITHUB_OUTPUT
 
       - id: "app_names"
         name: "Get app_names if necessary"
@@ -202,7 +206,7 @@ jobs:
       - name: Export Home
         run: echo "HOME=/root" >> $GITHUB_ENV
 
-      ##  Needs to be added so as to pull common Libs from bitbucket ##
+      ### Needs to be added so as to pull common Libs from bitbucket ##
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
         with:
@@ -218,7 +222,7 @@ jobs:
           key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: npm-
 
-       ### Authentings with Google Cloud to Push Image to GCR ###
+      ### Authenticate with Google Cloud to Push Image to GCR ###
       - id: "auth"
         name: "Authenticate to Google Cloud"
         uses: "google-github-actions/auth@v2"
@@ -246,7 +250,14 @@ jobs:
         if: ${{ env.BUILD_COMMAND }}
         run: $BUILD_COMMAND
 
-      - name: "Authenticating docker to push to gcr"
+      - name: "Authenticating docker for zendesk-base-images dependencies"
+        uses: docker/login-action@v3
+        with:
+          registry: "${{ steps.image_name.outputs.ZENDESK_BASE_IMAGES_DOMAIN }}"
+          username: "oauth2accesstoken"
+          password: "${{ steps.auth.outputs.access_token }}"
+
+      - name: "Authenticating docker to push to gcr domain"
         if: ${{ env.GCR_ENABLED == 'true' }}
         uses: docker/login-action@v3
         with:
@@ -254,7 +265,7 @@ jobs:
           username: "oauth2accesstoken"
           password: "${{ steps.auth.outputs.access_token }}"
 
-      - name: "Authenticating docker to push to gar"
+      - name: "Authenticating docker to push to gar domain"
         if: ${{ env.GAR_ENABLED == 'true' }}
         uses: docker/login-action@v3
         with:
@@ -292,7 +303,7 @@ jobs:
           TAGS: ${{ steps.get_image_tag.outputs.image_tag }}
           IMAGE_NAME: ${{ steps.image_name.outputs.gar_image_name }}
 
-      ##Deploy to dev
+      ### Deploy to dev
       - name: "Checkout k8s manifests"
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/exceptional_stage_deploy.yml
+++ b/.github/workflows/exceptional_stage_deploy.yml
@@ -95,6 +95,7 @@ env:
   GAR_ENABLED: ${{ vars.GAR_ENABLED || 'true' }}
   GCR_DEFAULT_REPO: ${{ vars.GCR_DEFAULT_REPO }}
   GAR_DEFAULT_REPO: ${{ vars.GAR_DEFAULT_REPO }}
+  ZENDESK_BASE_IMAGES_REPO: ${{ vars.ZENDESK_BASE_IMAGES_REPO || 'europe-west1-docker.pkg.dev/common-main-cfc4/zendesk-base-images' }}
   REGION: ${{ inputs.region }}
   AVAILABLE_REGIONS_FOR_DEPLOYMENT: ${{ vars.AVAILABLE_REGIONS_FOR_DEPLOYMENT }}
   CEREBRO_TEAM: ${{ inputs.cerebro_team }}
@@ -164,6 +165,8 @@ jobs:
             IMAGE_NAME=$GCR_IMAGE_NAME
           fi
 
+          ZENDESK_BASE_IMAGES_DOMAIN=$(echo $ZENDESK_BASE_IMAGES_REPO | cut -d '/' -f 1)
+
           echo "gcr_domain=$GCR_DOMAIN" >> $GITHUB_OUTPUT
           echo "gar_domain=$GAR_DOMAIN" >> $GITHUB_OUTPUT
           echo "gcr_image_repo=$GCR_IMAGE_REPO" >> $GITHUB_OUTPUT
@@ -171,6 +174,8 @@ jobs:
           echo "gcr_image_name=$GCR_IMAGE_NAME" >> $GITHUB_OUTPUT
           echo "gar_image_name=$GAR_IMAGE_NAME" >> $GITHUB_OUTPUT
           echo "image_name=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          echo "zendesk_base_images_domain=$ZENDESK_BASE_IMAGES_DOMAIN" >> $GITHUB_OUTPUT
+
 
       - id: "app_names"
         name: "Get app_names if necessary"
@@ -245,6 +250,13 @@ jobs:
       - name: build
         if: ${{ env.BUILD_COMMAND }}
         run: $BUILD_COMMAND
+
+      - name: "Authenticating docker for zendesk-base-images dependencies"
+        uses: docker/login-action@v3
+        with:
+          registry: "${{ steps.image_name.outputs.ZENDESK_BASE_IMAGES_DOMAIN }}"
+          username: "oauth2accesstoken"
+          password: "${{ steps.auth.outputs.access_token }}"
 
       - name: "Authenticating docker to push to gcr"
         if: ${{ env.GCR_ENABLED == 'true' }}

--- a/.github/workflows/merged-pr.yml
+++ b/.github/workflows/merged-pr.yml
@@ -111,6 +111,7 @@ env:
   GAR_ENABLED: ${{ vars.GAR_ENABLED || 'true' }}
   GCR_DEFAULT_REPO: ${{ vars.GCR_DEFAULT_REPO }}
   GAR_DEFAULT_REPO: ${{ vars.GAR_DEFAULT_REPO }}
+  ZENDESK_BASE_IMAGES_REPO: ${{ vars.ZENDESK_BASE_IMAGES_REPO || 'europe-west1-docker.pkg.dev/common-main-cfc4/zendesk-base-images' }}
   AVAILABLE_REGIONS_FOR_DEPLOYMENT: ${{ vars.AVAILABLE_REGIONS_FOR_DEPLOYMENT }}
   REGION: ${{ inputs.region }}
   CEREBRO_TEAM: ${{ inputs.cerebro_team }}
@@ -239,6 +240,8 @@ jobs:
             IMAGE_NAME=$GCR_IMAGE_NAME
           fi
 
+          ZENDESK_BASE_IMAGES_DOMAIN=$(echo $ZENDESK_BASE_IMAGES_REPO | cut -d '/' -f 1)
+
           echo "gcr_domain=$GCR_DOMAIN" >> $GITHUB_OUTPUT
           echo "gar_domain=$GAR_DOMAIN" >> $GITHUB_OUTPUT
           echo "gcr_image_repo=$GCR_IMAGE_REPO" >> $GITHUB_OUTPUT
@@ -246,6 +249,7 @@ jobs:
           echo "gcr_image_name=$GCR_IMAGE_NAME" >> $GITHUB_OUTPUT
           echo "gar_image_name=$GAR_IMAGE_NAME" >> $GITHUB_OUTPUT
           echo "image_name=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          echo "zendesk_base_images_domain=$ZENDESK_BASE_IMAGES_DOMAIN" >> $GITHUB_OUTPUT
 
       - id: "app_names"
         name: "Get app_names if necessary"
@@ -308,6 +312,13 @@ jobs:
           token_format: "access_token"
           workload_identity_provider: "${{ secrets.WIF_PROVIDER_NAME }}"
           service_account: ${{ secrets.GSA_GCR_EMAIL }}
+
+      - name: "Authenticating docker for zendesk-base-images dependencies"
+        uses: docker/login-action@v3
+        with:
+          registry: "${{ steps.image_name.outputs.ZENDESK_BASE_IMAGES_DOMAIN }}"
+          username: "oauth2accesstoken"
+          password: "${{ steps.auth.outputs.access_token }}"
 
       - name: "Authenticating docker to push to gcr"
         if: ${{ env.GCR_ENABLED == 'true' }}


### PR DESCRIPTION
zendesk-base-images are served from europe-west1-docker.pkg.dev repository
this pr adds support for docker-login action to authenticate to the above repository, in turn this will allow Dockerfile images based on zendesk-base-images to be used.

for all other use cases like docker.io nothing will change